### PR TITLE
New lib: deferred-queue

### DIFF
--- a/examples/callbacks-deferred-queue.js
+++ b/examples/callbacks-deferred-queue.js
@@ -1,0 +1,71 @@
+require('../lib/fakes');
+var dq = require('deferred-queue');
+
+module.exports = function upload(stream, idOrPath, tag, done) {
+    var blob = blobManager.create(account);
+    var tx = db.begin();
+    var blobId, file, version, fileId;
+    dq ()
+        .on ("error", function (error){console.log(error)
+          tx.rollback();
+        })
+        .push (function writeBlob(callback) {
+            blob.put(stream, callback);
+        })
+        .push (function afterBlobWritten(callback) {
+            blobId = undefined // iBlobId;
+            self.byUuidOrPath(idOrPath).get(callback);
+        })
+        .push (function afterFileFetched(callback) {
+            file = undefined; //iFile;
+            var previousId = file ? file.version : null;
+            version = {
+                userAccountId: userAccount.id,
+                date: new Date(),
+                blobId: blobId,
+                creatorId: userAccount.id,
+                previousId: previousId,
+                mergedId: null,
+                mergeType: 'mine',
+                comment: '',
+                tag: tag
+            };
+            version.id = Version.createHash(version);
+            Version.insert(version).execWithin(tx, callback);
+        })
+        .push (function afterVersionInserted(callback) {
+            if (!file) {
+                var splitPath = idOrPath.split('/');
+                var fileName = splitPath[splitPath.length - 1];
+                var newId = uuid.v1();
+                self.createQuery(idOrPath, {
+                    id: newId,
+                    userAccountId: userAccount.id,
+                    type: 'file',
+                    name: fileName,
+                    version: version.id
+                }, function (err, q) {
+                    if (err) return backoff(err);
+                    q.execWithin(tx, function (err) {
+                        callback(err, newId);
+                    });
+
+                })
+            }
+            else return callback(null, file.id);
+        }, function (error, id){
+          fileId = id;
+        })
+        .push (function afterFileExists(callback) {
+            FileVersion.insert({fileId: fileId, versionId: version.id})
+                .execWithin(tx, callback);
+        })
+        .push (function afterFileVersionInserted(callback) {
+            File.whereUpdate({id: fileId}, { version: version.id })
+                .execWithin(tx, callback);
+        })
+        .push (function afterFileUpdated(callback) {
+            tx.commit(callback);
+            done ();
+        });
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "stratifiedjs": "~0.14.0",
     "bluebird": "~0.7.9-1",
     "q": "~0.9.7",
-    "kew": "~0.2.2"
+    "kew": "~0.2.2",
+    "deferred-queue": "~0.3.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Hi,

Some months ago I made a control flow lib aimed to be the glue between sync-style api calls and pure async modules. It's very similar to async.queue and async.waterfall but it is 2,6 times faster and allows you to pause/resume the queue at any time. The error handling and the pass of the parameters through the tasks are a bit different.

``` bash
$ node performance.js --n 10000 --t 1 --file ./examples/callbacks-deferred-queue.js
{"time":299,"mem":56.9296875,"errors":0,"lastErr":null}

$ node performance.js --n 10000 --t 1 --file ./examples/callbacks-async-waterfall
{"time":813,"mem":59.12109375,"errors":0,"lastErr":null}
```

[deferred-queue](https://github.com/gagle/node-deferred-queue)
